### PR TITLE
Remove refernce to (now unexisting) Cygnus 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ The tutorial uses [cUrl](https://ec.haxx.se/) commands throughout, but is also
 available as
 [Postman documentation](https://fiware.github.io/tutorials.Historic-Context/)
 
-> **Note** There are breaking changes to the setup of Cygnus between 1.x and
-> 2.x. This tutorial is describing the use of Cygnus 1.9.0
-
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4824d3171f823935dcab)
 
 -   このチュートリアルは[日本語](README.ja.md)でもご覧いただけます。


### PR DESCRIPTION
Cygnus 2.x no longer exist (Draco is the one which takes this place) so I understand the Note is obsolete and should be removed to avoid confusion in users following this tutorial.